### PR TITLE
fix broken image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -19,6 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const ItemPreview = (props) => {
   const item = props.item;
+  const imageToDisplay = item.image ? item.image : '/placeholder.png'
 
   const handleClick = (ev) => {
     ev.preventDefault();
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={imageToDisplay}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const ItemPreview = (props) => {
   const item = props.item;
-  const imageToDisplay = item.image ? item.image : '/placeholder.png'
+  const imageToDisplay = item.image ? item.image : "/placeholder.png";
 
   const handleClick = (ev) => {
     ev.preventDefault();


### PR DESCRIPTION
Now the placeholder image is displayed when no image is provided when creating an item, this fixes #2
![fix_img](https://user-images.githubusercontent.com/159034/184532404-053eca55-055c-4ab0-b7f8-59993bf0145c.png)

